### PR TITLE
style: adjust disabled button styles and improve infocard hover effect

### DIFF
--- a/assets/styles/component.css
+++ b/assets/styles/component.css
@@ -60,10 +60,6 @@ section:has(.infocard) {
       grid-template-rows: auto auto 1fr auto;
       border-bottom: none;
 
-      &:hover {
-        background-color: var(--link-card-light-grey-hover);
-      }
-
       h3 {
         margin-block-end: auto;
       }
@@ -159,11 +155,16 @@ section:has(.infocard) {
       }
     }
 
+
+    &.cosplay-info img,
+    &:not(.costume) picture {
+      aspect-ratio: 1 / 1;
+    }
+
     &.cosplay-info img,
     picture {
       width: 100%;
       height: auto;
-      aspect-ratio: 1 / 1;
       max-width: 100%;
       border-radius: var(--rounded-card-corners);
       grid-area: img;
@@ -219,7 +220,7 @@ section:has(.infocard) {
     height: 4px;
     border-radius: 50%;
     background: var(--dark-font);
-    box-shadow: 
+    box-shadow:
       0 11px 0 1px var(--dark-font),
       0 22px 0 2px var(--dark-font);
   }
@@ -233,7 +234,7 @@ section:has(.infocard) {
     height: 8px;
     border-radius: 50%;
     background: var(--dark-font);
-    box-shadow: 
+    box-shadow:
       0 11px 0 -1px var(--dark-font),
       0 22px 0 -2px var(--dark-font);
   }
@@ -266,6 +267,11 @@ section:has(.infocard) {
 #certificates {
   /* Reserve space to prevent layout shift during content loading */
   min-height: 200px;
+}
+
+.infocard.link:hover,
+#certificates>ul>li:hover {
+  background-color: var(--link-card-light-grey-hover);
 }
 
 #certificates>ul {

--- a/assets/styles/index.css
+++ b/assets/styles/index.css
@@ -93,9 +93,13 @@ button,
   }
 }
 
-.button[href=""] {
+.button[href=""],
+.button:disabled,
+button.button:disabled {
   cursor: not-allowed;
   background-color: var(--primary-button-disabled-color);
+  pointer-events: none;
+  opacity: 0.7;
 }
 
 h2 {

--- a/index.js
+++ b/index.js
@@ -50,19 +50,20 @@ export function cosplays() {
   cosPortfolio.forEach((cos) => {
     const li = document.createElement("li");
     const avifUrl = cos.imageUrl.replace(/\.(jpg|jpeg|png)$/i, '.avif');
+    const isDisabled = !cos.buildbookUrl || cos.buildbookUrl.trim() === '';
     li.innerHTML = `
-        <div class="infocard costume">
-                <h3>${cos.title}</h3>
-                <p class="source">${cos.source}</p>
-                <picture>
-                  <source srcset="${avifUrl}" type="image/avif">
-                  <img src="${cos.imageUrl}" alt="${cos.title} from ${cos.source}" loading="lazy" />
-                </picture>
-                <p class="genres">${cos.genres}</p>
-                <p>${cos.description}</p>
-                <a class="button primary" href="${cos.buildbookUrl}">Build Book</a>
-        </div>
-            `;
+      <div class="infocard costume">
+          <h3>${cos.title}</h3>
+          <p class="source">${cos.source}</p>
+          <picture>
+            <source srcset="${avifUrl}" type="image/avif">
+            <img src="${cos.imageUrl}" alt="${cos.title} from ${cos.source}" loading="lazy" />
+          </picture>
+          <p class="genres">${cos.genres}</p>
+          <p>${cos.description}</p>
+          <a class="button primary" href="${cos.buildbookUrl || ''}" ${isDisabled ? 'aria-disabled="true"' : ''}>Build Book</a>
+      </div>
+        `;
     ul.appendChild(li);
   });
   return ul;


### PR DESCRIPTION
This pull request refines the UI and accessibility for cosplay cards and buttons, focusing on improving hover effects, image styling, and disabled button handling. The changes ensure consistent visual feedback and more accessible interactions, especially for buttons and cards that are not actionable.

**UI and Accessibility Improvements**

* Disabled buttons now show a not-allowed cursor, reduced opacity, and prevent interaction via pointer events, improving clarity for users. (`assets/styles/index.css`)
* "Build Book" buttons for cosplays without a valid URL are now visually disabled and marked with `aria-disabled="true"`, enhancing accessibility and preventing navigation to empty links. (`index.js`) [[1]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346R53) [[2]](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L63-R64)

**Visual Consistency for Cards and Images**

* Removed hover background color from `.infocard` cards inside sections and moved it to `.infocard.link` and certificate list items, ensuring only actionable cards highlight on hover. (`assets/styles/component.css`) [[1]](diffhunk://#diff-f83484b66f0fd63ba372a0e2b68734f93c49e3911981f9448dcfb207d35a159aL63-L66) [[2]](diffhunk://#diff-f83484b66f0fd63ba372a0e2b68734f93c49e3911981f9448dcfb207d35a159aR272-R276)
* Improved image aspect ratio handling for cosplay and non-costume cards by refining CSS selectors, ensuring images display consistently as squares. (`assets/styles/component.css`)