### PR TITLE
feat: update links for localization in index and work pages

### DIFF
--- a/src/pages/de/index.astro
+++ b/src/pages/de/index.astro
@@ -41,7 +41,7 @@ import Ressources from "../../components/Ressources.astro";
               Cosplays von Grund auf und habe kurz darauf meine Karriere als
               Softwareentwicklerin gestartet.
             </p>
-            <a class="button primary" href="/work.html"> Meine Arbeit </a>
+            <a class="button primary" href="/de/work"> Meine Arbeit </a>
           </div>
           <div class="pfp-hover">
             <Picture

--- a/src/pages/de/work.astro
+++ b/src/pages/de/work.astro
@@ -82,7 +82,7 @@ import BaseLayout from "../../layouts/BaseLayout.astro";
                 Prozess, der die Figuren und Geschichten für mich greifbar
                 macht.
               </p>
-              <a class="button primary" href="/">Mein Cosplay-Portfolio</a>
+              <a class="button primary" href="/de">Mein Cosplay-Portfolio</a>
             </div>
           </div>
         </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -42,7 +42,7 @@ import Ressources from "../components/Ressources.astro";
               all while starting my career as a software developer shortly
               after.
             </p>
-            <a class="button primary" href="/work.html"> About my Work </a>
+            <a class="button primary" href="/work"> About my Work </a>
           </div>
           <div class="pfp-hover">
             <Picture


### PR DESCRIPTION
This pull request updates navigation links on the German and English home and work pages to use the correct URL paths, improving routing consistency and removing `.html` extensions.

Navigation link updates:

* Changed the "Meine Arbeit" button link in `src/pages/de/index.astro` to `/de/work` instead of `/work.html`, ensuring proper routing for the German work page.
* Changed the "Mein Cosplay-Portfolio" button link in `src/pages/de/work.astro` to `/de` instead of `/`, ensuring correct navigation to the German homepage.
* Changed the "About my Work" button link in `src/pages/index.astro` to `/work` instead of `/work.html`, ensuring proper routing for the English work page.